### PR TITLE
Use azul/zulu-openjdk docker image on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/shadow
   docker:
-    - image: cimg/openjdk:17.0
+    - image: azul/zulu-openjdk:17-latest
   environment:
     - TERM: "dumb"
     - GRADLE_OPTS: "-Xmx1024m"


### PR DESCRIPTION
Easier to track JDK updates, see https://hub.docker.com/r/azul/zulu-openjdk