### PR TITLE
Fix for PropertiesFileTransformer breaks Reproducible builds in 8.1.1

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/CleanProperties.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/CleanProperties.groovy
@@ -1,32 +1,36 @@
-/*
- * Source https://stackoverflow.com/a/39043903/519333
- */
 package com.github.jengelman.gradle.plugins.shadow.internal
 
 class CleanProperties extends Properties {
-    private static class StripFirstLineStream extends FilterOutputStream {
 
-        private boolean firstLineSeen = false
+    private static class StripCommentsWithTimestampBufferedWriter extends BufferedWriter {
 
-        StripFirstLineStream(final OutputStream out) {
-            super(out)
+        private final int lengthOfExpectedTimestamp
+
+        StripCommentsWithTimestampBufferedWriter(final Writer out) {
+            super(out);
+
+            lengthOfExpectedTimestamp = ("#" + new Date().toString()).length()
         }
 
         @Override
-        void write(final int b) throws IOException {
-            if (firstLineSeen) {
-                super.write(b)
-            } else if (b == '\n') {
-                super.write(b)
-
-                firstLineSeen = true
+        void write(final String str) throws IOException {
+            if (couldBeCommentWithTimestamp(str)) {
+                return
             }
+
+            super.write(str)
         }
 
+        private boolean couldBeCommentWithTimestamp(final String str) {
+            return str != null &&
+                    str.startsWith("#") &&
+                    str.length() == lengthOfExpectedTimestamp
+        }
     }
 
     @Override
-    void store(final OutputStream out, final String comments) throws IOException {
-        super.store(new StripFirstLineStream(out), null)
+    void store(final Writer writer, final String comments) throws IOException
+    {
+        super.store(new StripCommentsWithTimestampBufferedWriter(writer), comments);
     }
 }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformerTest.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformerTest.groovy
@@ -40,21 +40,42 @@ final class PropertiesFileTransformerTest extends TransformerTestSupport {
     void testTransformation() {
         transformer.transform(new TransformerContext(MANIFEST_NAME, getResourceStream(MANIFEST_NAME), Collections.<Relocator>emptyList(), new ShadowStats()))
 
+        def testableZipFile = doTransformAndGetTransformedFile(transformer, false)
+        def targetLines = readFrom(testableZipFile, MANIFEST_NAME)
+
+        assertFalse(targetLines.isEmpty())
+
+        assertTrue(targetLines.contains("Manifest-Version=1.0"))
+    }
+
+    @Test
+    void testTransformationPropertiesAreReproducible() {
+        transformer.transform(new TransformerContext(MANIFEST_NAME, getResourceStream(MANIFEST_NAME), Collections.<Relocator>emptyList(), new ShadowStats()))
+
+        def firstRunTransformedFile = doTransformAndGetTransformedFile(transformer, true)
+        def firstRunTargetLines = readFrom(firstRunTransformedFile, MANIFEST_NAME)
+
+        Thread.sleep(1000) // wait for 1sec to ensure timestamps in properties would change
+
+        def secondRunTransformedFile = doTransformAndGetTransformedFile(transformer, true)
+        def secondRunTargetLines = readFrom(secondRunTransformedFile, MANIFEST_NAME)
+
+        assertEquals(firstRunTargetLines, secondRunTargetLines)
+    }
+
+    static File doTransformAndGetTransformedFile(final PropertiesFileTransformer transformer, final boolean  preserveFileTimestamps) {
         def testableZipFile = File.createTempFile("testable-zip-file-", ".jar")
         def fileOutputStream = new FileOutputStream(testableZipFile)
         def bufferedOutputStream = new BufferedOutputStream(fileOutputStream)
         def zipOutputStream = new ZipOutputStream(bufferedOutputStream)
 
         try {
-            transformer.modifyOutputStream(zipOutputStream, false)
+            transformer.modifyOutputStream(zipOutputStream, preserveFileTimestamps)
         } finally {
             zipOutputStream.close()
         }
-        def targetLines = readFrom(testableZipFile, MANIFEST_NAME)
 
-        assertFalse(targetLines.isEmpty())
-
-        assertTrue(targetLines.contains("Manifest-Version=1.0"))
+        return testableZipFile;
     }
 
     static List<String> readFrom(File jarFile, String resourceName) {


### PR DESCRIPTION
[PR](https://github.com/johnrengelman/shadow/pull/858) open for main shadow repo

----
Please have a look, added a test (which should fail with 8.1.1) and a fix on CleanProperties.

Removing the timestamp which default Properties class is adding could be tricky. I changed the previous mechanism to be bit more flexible (was not working either as some blank comment line is added now), but either way don't know if is a good approach. Please check